### PR TITLE
Patch out lalsuite in install_requires

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,13 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 130e01427bdc7a5b404a84d1dcfc5c61fc3522427955d24c63ece2b037a4725d
+  patches:
+    # clean requirements for conda-forge
+    #   - don't require 'lalsuite', we only need lal
+    - requirements.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [win]
 
@@ -33,6 +37,9 @@ requirements:
     - six
 
 test:
+  requires:
+    - pip
+    - pytest
   imports:
     - dqsegdb
     - dqsegdb.apicalls
@@ -40,6 +47,11 @@ test:
     - dqsegdb.jsonhelper
     - dqsegdb.urifunctions
   commands:
+    # check requirements
+    - python -m pip check
+    # run test suite
+    - python -m pytest -ra -v --pyargs dqsegdb.tests
+    # check scripts
     - ligolw_dq_query_dqsegdb --help
     - ligolw_publish_threaded_dqxml_dqsegdb --help
     - ligolw_segment_insert_dqsegdb --help

--- a/recipe/requirements.patch
+++ b/recipe/requirements.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 8df0420..d9b33ba 100644
+--- a/setup.py
++++ b/setup.py
+@@ -136,7 +136,6 @@ setup(name=PACKAGENAME,
+       setup_requires=['setuptools'],
+       install_requires=[
+           'gwdatafind',
+-          'lalsuite',
+           'ligo-segments',
+           'lscsoft-glue>=1.55.0',
+           'pyOpenSSL>=0.14',


### PR DESCRIPTION
This PR adds a patch to remove `lalsuite` from the setup.py `install_requires` list, since we can depend on `python-lal` explicitly here. I also beefed up the tests to catch this sort of thing upstream in the future.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
